### PR TITLE
Add basic stable audio distillation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# capstone
+# Capstone Stable Audio Distillation
+
+This project demonstrates a minimal training script that performs knowledge distillation on audio models using the [stable-audio-tools](https://github.com/Stability-AI/stable-audio-tools) library.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+The script expects `torch`, `torchaudio`, and `stable-audio-tools` to be available.
+
+## Usage
+
+Run the training script by specifying a dataset directory and teacher checkpoint:
+
+```bash
+python train.py \
+    --dataset /path/to/librispeech \
+    --teacher /path/to/teacher.ckpt \
+    --epochs 5 \
+    --batch-size 4 \
+    --output-dir checkpoints
+```
+
+The distilled student checkpoints will be saved in the `--output-dir` directory.
+
+## Testing
+
+Basic unit tests are provided and can be run with:
+
+```bash
+pytest -q
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torchaudio
+stable-audio-tools

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,18 @@
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+spec = importlib.util.spec_from_file_location("train", os.path.join(ROOT, "train.py"))
+train = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(train)
+parse_args = train.parse_args
+
+
+def test_parse_args_defaults():
+    args = parse_args(['--dataset', 'data', '--teacher', 'teacher.pt'])
+    assert args.dataset == 'data'
+    assert args.teacher == 'teacher.pt'
+    assert args.epochs == 1
+    assert args.batch_size == 1
+    assert args.output_dir == 'checkpoints'

--- a/train.py
+++ b/train.py
@@ -1,0 +1,102 @@
+import argparse
+import os
+
+try:
+    import torch
+    import torchaudio
+except Exception:  # pragma: no cover - dependencies might be missing during tests
+    torch = None
+    torchaudio = None
+
+try:
+    import stable_audio_tools as sat
+except ImportError:  # pragma: no cover - stable-audio-tools may not be installed
+    sat = None
+
+
+base_class = torch.nn.Module if torch else object
+
+
+class StudentModel(base_class):
+    """Simple student model using stable-audio-tools components if available."""
+
+    def __init__(self):
+        if torch is None:
+            raise ImportError("PyTorch is required to use StudentModel")
+
+        super().__init__()
+        if sat and hasattr(sat, "Model"):
+            self.model = sat.Model()
+        else:  # fallback simple network
+            self.model = torch.nn.Sequential(
+                torch.nn.Conv1d(1, 16, kernel_size=3, padding=1),
+                torch.nn.ReLU(),
+                torch.nn.Conv1d(16, 1, kernel_size=3, padding=1),
+            )
+
+    def forward(self, x):
+        return self.model(x)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Stable Audio Knowledge Distillation")
+    parser.add_argument("--dataset", required=True, help="Path to training dataset")
+    parser.add_argument("--teacher", required=True, help="Path to teacher model checkpoint")
+    parser.add_argument("--student", default=None, help="Optional path to student checkpoint")
+    parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    parser.add_argument("--batch-size", type=int, default=1, help="Training batch size")
+    parser.add_argument("--output-dir", default="checkpoints", help="Directory to save checkpoints")
+    return parser.parse_args(argv)
+
+
+def load_teacher(path: str):
+    if sat and hasattr(sat, "load_model"):
+        return sat.load_model(path)
+    # Fallback dummy teacher
+    model = StudentModel()
+    if os.path.exists(path):
+        model.load_state_dict(torch.load(path))
+    return model
+
+
+def main(argv=None):
+    if torch is None or torchaudio is None:
+        raise ImportError("PyTorch and torchaudio are required for training")
+    args = parse_args(argv)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    teacher = load_teacher(args.teacher)
+    student = StudentModel()
+    if args.student and os.path.exists(args.student):
+        student.load_state_dict(torch.load(args.student))
+
+    criterion = torch.nn.MSELoss()
+    optimizer = torch.optim.Adam(student.parameters())
+
+    dataset = torchaudio.datasets.LIBRISPEECH(
+        args.dataset, url="train-clean-100", download=False
+    )
+    loader = torch.utils.data.DataLoader(
+        dataset, batch_size=args.batch_size, shuffle=True
+    )
+
+    teacher.eval()
+    for epoch in range(args.epochs):
+        student.train()
+        for waveforms, _, _, _, _ in loader:
+            with torch.no_grad():
+                teacher_out = teacher(waveforms)
+            student_out = student(waveforms)
+            loss = criterion(student_out, teacher_out)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        ckpt = os.path.join(args.output_dir, f"student_epoch_{epoch+1}.pt")
+        torch.save(student.state_dict(), ckpt)
+
+    return student
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- implement `train.py` for stable-audio knowledge distillation
- document setup and usage in README
- add dependencies list
- create basic unit test for argument parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf8112f68832c91fc7833d314e193